### PR TITLE
fix(github-actions): fix CVE-2025-30066 and pre-emptive security measures

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,6 +4,7 @@ profile: safety
 
 exclude_paths:
 - .github/
+- .ansible/
 
 use_default_rules: true
 

--- a/.github/workflows/build-ubuntu-image.yaml
+++ b/.github/workflows/build-ubuntu-image.yaml
@@ -28,6 +28,8 @@ env:
   PACKER_CACHE_DIR: /home/runner/.build/cache/packer
   PACKER_LOG: 1
 
+permissions: {}
+
 jobs:
   build-ubuntu-image:
     strategy:
@@ -37,6 +39,7 @@ jobs:
         arch_plus_device_type: ["arm64+raspi", "amd64"]
     runs-on: ubuntu-24.04
     timeout-minutes: 180
+    environment: release
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/build-ubuntu-image.yaml
+++ b/.github/workflows/build-ubuntu-image.yaml
@@ -68,7 +68,7 @@ jobs:
     - name: Install ansible
       run: |
         # install globally as we need to run packer build with sudo, so installing just for current user won't work
-        sudo pip install -r ./requirements.txt
+        sudo pip install -r ./requirements.txt --ignore-installed
 
     - name: Prepare directories + parameters file
       env:

--- a/.github/workflows/build-ubuntu-image.yaml
+++ b/.github/workflows/build-ubuntu-image.yaml
@@ -28,7 +28,8 @@ env:
   PACKER_CACHE_DIR: /home/runner/.build/cache/packer
   PACKER_LOG: 1
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   build-ubuntu-image:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   detect-changes:
     outputs:
@@ -36,7 +39,7 @@ jobs:
 
     - name: Determine what files types have changed
       id: changed-files-yaml
-      uses: tj-actions/changed-files@dcc7a0cba800f454d79fff4b993e8c3555bcc0a8 # v45
+      uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46
       with:
         files_yaml: |
           actions:
@@ -47,6 +50,7 @@ jobs:
           - '**.j2'
           - '!.github/**'
           - '!.pre-commit-config.yaml'
+          - '.ansible-lint'
           packer:
           - '**.pkr.hcl'
           renovate:


### PR DESCRIPTION
- Fix CVE-2025-30066 by upgrading to tj-actions/changed-files to v46
- Rotate all secrets used in Github Actions
- Setup pre-emptive measures to limit the blast radius of future vulnerabilities in github actions
  - explicitly set permission for default GITHUB_TOKEN to limit its capabilities to whats needed
  - Move all repository wide secrets to environments and set environments explicitly on jobs that need those secrets